### PR TITLE
Build --static on windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ trillions of graphs can be processed on a single computer.
                   include_dirs=['src'],
                   libraries=libraries_list,
                   define_macros=[('B_64', None)],
+                  extra_link_args=["-static" if sys.platform == 'win32' else '']
                   ),
         ],
       test_suite='graphillion.test',


### PR DESCRIPTION
This small changes ensure that when building under mingw (with conda or a plain mingw) the resulting _graphillion.pyd library does not have extra dependencies that are MinGW-specific such as libstdc++ or libgcc. This allows to build further wheels and eggs that run out of the box. The (minor) downside is that the shared library is about twice bigger (1MB vs 500KB).
