### PR TITLE
Update setup.py:url

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ trillions of graphs can be processed on a single computer.
       keywords=['graph', 'set', 'math', 'network'],
       author=release.authors[0][0],
       author_email=release.authors[0][1],
-      url='http://graphillion.org/',
+      url='https://github.com/takemaru/graphillion',
       license=release.license,
       packages = ['graphillion'],
       ext_modules=[


### PR DESCRIPTION
http://graphillion.org now redirects to https://github.com/takemaru/graphillion

Update setup.py metadata accordingly