### PR TITLE
Variable ordering

### DIFF
--- a/graphillion/graphset.py
+++ b/graphillion/graphset.py
@@ -1558,7 +1558,9 @@ class GraphSet(object):
             edges to be processed in the internal graphset operations.
             The default is 'bfs', the breadth-first search from
             `source`.  Other options include 'dfs', the depth-first
-            search, and 'as-is', the order of `universe` list.
+            search, 'greedy', best-first search with respect to
+            the number of unused incident edges, and 'as-is', 
+            the order of `universe` list.
 
           source: Optional.  This argument specifies the starting
             point of the edge traversal.

--- a/graphillion/graphset.py
+++ b/graphillion/graphset.py
@@ -1556,11 +1556,11 @@ class GraphSet(object):
 
           traversal: Optional.  This argument specifies the order of
             edges to be processed in the internal graphset operations.
-            The default is 'bfs', the breadth-first search from
-            `source`.  Other options include 'dfs', the depth-first
-            search, 'greedy', best-first search with respect to
-            the number of unused incident edges, and 'as-is', 
-            the order of `universe` list.
+            The default is 'greedy', best-first search from `source`
+            with respect to the number of unused incident edges.
+            Other options include 'bfs', the breadth-first search, 
+            'dfs', the depth-first search, and 'as-is', the order of
+            `universe` list.
 
           source: Optional.  This argument specifies the starting
             point of the edge traversal.

--- a/graphillion/test/graphset.py
+++ b/graphillion/test/graphset.py
@@ -48,7 +48,8 @@ g1234 = [e1, e2, e3, e4]
 class TestGraphSet(unittest.TestCase):
 
     def setUp(self):
-        GraphSet.set_universe([e1 + (.3,), e2 + (-.2,), e3 + (-.2,), e4 + (.4,)])
+        GraphSet.set_universe([e1 + (.3,), e2 + (-.2,), e3 + (-.2,), e4 + (.4,)],
+                              traversal='bfs', source=1)
 
     def tearDown(self):
         pass
@@ -57,7 +58,8 @@ class TestGraphSet(unittest.TestCase):
         GraphSet.set_universe([('i', 'ii')])
         self.assertEqual(GraphSet.universe(), [('i', 'ii')])
 
-        GraphSet.set_universe([e1 + (.3,), e2 + (-.2,), e3 + (-.2,), e4 + (.4,)])
+        GraphSet.set_universe([e1 + (.3,), e2 + (-.2,), e3 + (-.2,), e4 + (.4,)],
+                              traversal='bfs', source=1)
         self.assertEqual(GraphSet.universe(),
                          [e1 + (.3,), e2 + (-.2,), e3 + (-.2,), e4 + (.4,)])
 
@@ -65,6 +67,11 @@ class TestGraphSet(unittest.TestCase):
                               traversal='dfs', source=1)
         self.assertEqual(GraphSet.universe(),
                          [e2 + (-.2,), e4 + (.4,), e1 + (.3,), e3 + (-.2,)])
+
+        GraphSet.set_universe([e1 + (.3,), e2 + (-.2,), e3 + (-.2,), e4 + (.4,)],
+                              traversal='greedy', source=3)
+        self.assertEqual(GraphSet.universe(),
+                         [e2 + (-.2,), e1 + (.3,), e3 + (-.2,), e4 + (.4,)])
 
         self.assertRaises(KeyError, GraphSet.set_universe, [(1,2), (2,1)])
 


### PR DESCRIPTION
Add a new graph-traversal method for edge ordering and set it as default. In many cases (especially for road networks), the method outperforms the performance of the current default 'bfs' according to the following tech report:
Y. Inoue and S. Minato, "Acceleration of ZDD Construction for Subgraph Enumeration via Path-width Optimization" (URL:  http://www-alg.ist.hokudai.ac.jp/~thomas/TCSTR/tcstr_16_80/tcstr_16_80.pdf).