### PR TITLE
Fix failed generator

### DIFF
--- a/graphillion/graphset.py
+++ b/graphillion/graphset.py
@@ -651,7 +651,10 @@ class GraphSet(object):
           rand_iter(), max_iter(), min_iter()
         """
         for g in self._ss.__iter__():
-            yield GraphSet._conv_ret(g)
+            try:
+                yield GraphSet._conv_ret(g)
+            except StopIteration:
+                return
 
     def rand_iter(self):
         """Iterates over graphs uniformly randomly.
@@ -678,7 +681,10 @@ class GraphSet(object):
           __iter__(), max_iter(), min_iter()
         """
         for g in self._ss.rand_iter():
-            yield GraphSet._conv_ret(g)
+            try:
+                yield GraphSet._conv_ret(g)
+            except StopIteration:
+                return
 
     def min_iter(self, weights=None):
         """Iterates over graphs in the ascending order of weights.
@@ -716,7 +722,10 @@ class GraphSet(object):
         if weights is None:
             weights = GraphSet._weights
         for g in self._ss.min_iter(weights):
-            yield GraphSet._conv_ret(g)
+            try:
+                yield GraphSet._conv_ret(g)
+            except StopIteration:
+                return
 
     def max_iter(self, weights=None):
         """Iterates over graphs in the descending order of weights.
@@ -753,7 +762,10 @@ class GraphSet(object):
         if weights is None:
             weights = GraphSet._weights
         for g in self._ss.max_iter(weights):
-            yield GraphSet._conv_ret(g)
+            try:
+                yield GraphSet._conv_ret(g)
+            except StopIteration:
+                return
 
     def __contains__(self, obj):
         """Returns True if `obj` is in the `self`, False otherwise.

--- a/graphillion/setset.py
+++ b/graphillion/setset.py
@@ -122,12 +122,18 @@ class setset(_graphillion.setset):
     def __iter__(self):
         i = _graphillion.setset.iter(self)
         while (True):
-            yield setset._conv_ret(next(i))
+            try:
+                yield setset._conv_ret(next(i))
+            except StopIteration:
+                return
 
     def rand_iter(self):
         i = _graphillion.setset.rand_iter(self)
         while (True):
-            yield setset._conv_ret(next(i))
+            try:
+                yield setset._conv_ret(next(i))
+            except StopIteration:
+                return
 
     def min_iter(self, weights=None, default=1):
         return self._optimize(weights, default, _graphillion.setset.min_iter)
@@ -143,7 +149,10 @@ class setset(_graphillion.setset):
                 ws[i] = w
         i = generator(self, ws)
         while (True):
-            yield setset._conv_ret(next(i))
+            try:
+                yield setset._conv_ret(next(i))
+            except StopIteration:
+                return
 
     def supersets(self, obj):
         if (not isinstance(obj, setset)):


### PR DESCRIPTION
This commit fixes issue #36 

Added `try` `except` to generators. The graphset.py and setset.py unit tests were ran on Python 3.6.7 and Python 2.7.15