### PR TITLE
Fix the bug of #45

### DIFF
--- a/src/graphillion/setset.cc
+++ b/src/graphillion/setset.cc
@@ -91,7 +91,7 @@ setset::random_iterator::random_iterator(const setset::random_iterator& i)
     : iterator(i), size_(i.size_) {
 }
 
-setset::random_iterator::random_iterator(const setset& ss) : iterator(ss) {
+setset::random_iterator::random_iterator(const setset& ss) : iterator(ss, set<elem_t>()) {
   this->size_ = algo_c(ss.zdd_);
   this->next();
 }
@@ -119,7 +119,7 @@ setset::weighted_iterator::weighted_iterator(const setset::weighted_iterator& i)
 
 setset::weighted_iterator::weighted_iterator(const setset& ss,
                                              vector<double> weights)
-    : iterator(ss), weights_(weights) {
+    : iterator(ss, set<elem_t>()), weights_(weights) {
   this->next();
 }
 


### PR DESCRIPTION
This pull request fixes the issue in #45: "GraphSet([[]]).min_iter() should return the set consisting of the empty graph but not so."

The cause of the bug is that next() is wrongly called twice in the constructors of setset::random_iterator and setset::weighted_iterator (called in both each constructor and its parent constructor).

This fix suppresses the call of next() in the parent constructors.
