### PR TITLE
implement bipartite_graphs()

### DIFF
--- a/graphillion/graphset.py
+++ b/graphillion/graphset.py
@@ -1987,7 +1987,7 @@ class GraphSet(object):
         return _graphillion._show_messages(flag)
 
     @staticmethod
-    def bipartite_graphs():
+    def bipartite_graphs(graphset=None):
         """
         """
         graph = []
@@ -1998,7 +1998,11 @@ class GraphSet(object):
 
         odd_gs = GraphSet(_graphillion._odd_edges_subgraphs(graph))
         odd_cycle_gs = odd_gs.cycles()
-        return GraphSet({}).non_supergraphs(odd_cycle_gs)
+
+        if graphset is None:
+          return GraphSet({}).non_supergraphs(odd_cycle_gs)
+
+        return graphset.non_supergraphs(odd_cycle_gs)
 
     @staticmethod
     def _traverse(indexed_edges, traversal, source):

--- a/graphillion/graphset.py
+++ b/graphillion/graphset.py
@@ -1987,6 +1987,20 @@ class GraphSet(object):
         return _graphillion._show_messages(flag)
 
     @staticmethod
+    def bipartite_graphs():
+        """
+        """
+        graph = []
+        for e in setset.universe():
+            assert e[0] in GraphSet._vertices and e[1] in GraphSet._vertices
+            graph.append(
+                (pickle.dumps(e[0], protocol=0), pickle.dumps(e[1], protocol=0)))
+
+        odd_gs = GraphSet(_graphillion._odd_edges_subgraphs(graph))
+        odd_cycle_gs = odd_gs.cycles()
+        return GraphSet({}).non_supergraphs(odd_cycle_gs)
+
+    @staticmethod
     def _traverse(indexed_edges, traversal, source):
         neighbors = {}
         for u, v in indexed_edges:

--- a/graphillion/graphset.py
+++ b/graphillion/graphset.py
@@ -1988,7 +1988,18 @@ class GraphSet(object):
 
     @staticmethod
     def bipartite_graphs(graphset=None):
-        """
+        """Returns a GraphSet of bipartite subgraphs.
+
+        Example:
+          >>> GraphSet.bipartite_graphs()
+          GraphSet([[], [(1, 4)], [(4, 5)], [(1, 2)], [(2, 5)], [(2, 3)], [(3, 6)], [( ...
+
+        Args:
+          graphset: Optional. A GraphSet object. Subgraphs to be stored
+            are selected from this object.
+
+        Returns:
+          A new GraphSet object.
         """
         graph = []
         for e in setset.universe():
@@ -2000,7 +2011,7 @@ class GraphSet(object):
         odd_cycle_gs = odd_gs.cycles()
 
         if graphset is None:
-          return GraphSet({}).non_supergraphs(odd_cycle_gs)
+            return GraphSet({}).non_supergraphs(odd_cycle_gs)
 
         return graphset.non_supergraphs(odd_cycle_gs)
 

--- a/graphillion/test/graphset.py
+++ b/graphillion/test/graphset.py
@@ -324,6 +324,11 @@ class TestGraphSet(unittest.TestCase):
         self.assertTrue([(1, 2), (1, 3), (2, 3)] not in gs)
         self.assertTrue([(1, 2), (1, 3), (2, 3), (3, 4)] not in gs)
 
+        graphset = GraphSet([[(1, 2), (1, 3), (2, 3)], [(1, 2), (2, 3), (3, 4)]])
+        gs = GraphSet.bipartite_graphs(graphset=graphset)
+        self.assertTrue([(1, 2), (2, 3), (3, 4)] in gs)
+        self.assertTrue([(1, 2), (1, 3), (3, 4)] not in gs)
+
         GraphSet.set_universe([(1, 2), (2, 3), (3, 4), (4, 5)])
         """
         1 --- 2 --- 3 --- 4 --- 5

--- a/graphillion/test/graphset.py
+++ b/graphillion/test/graphset.py
@@ -310,6 +310,27 @@ class TestGraphSet(unittest.TestCase):
         d = GraphSet.show_messages(a)
         self.assertFalse(d)
 
+    def test_bipartite_graphs(self):
+        GraphSet.set_universe([(1, 2), (1, 3), (2, 3), (3, 4)])
+        """
+        1 --- 2
+        |  /
+        3 --- 4
+        """
+        gs = GraphSet.bipartite_graphs()
+        self.assertEqual(len(gs), 2 ** 4 - 2)
+        self.assertTrue([(1, 2), (2, 3), (3, 4)] in gs)
+        self.assertTrue([] in gs)
+        self.assertTrue([(1, 2), (1, 3), (2, 3)] not in gs)
+        self.assertTrue([(1, 2), (1, 3), (2, 3), (3, 4)] not in gs)
+
+        GraphSet.set_universe([(1, 2), (2, 3), (3, 4), (4, 5)])
+        """
+        1 --- 2 --- 3 --- 4 --- 5
+        """
+        gs = GraphSet.bipartite_graphs()
+        self.assertEqual(len(gs), 16)
+
     def test_comparison(self):
         gs = GraphSet([g12])
         self.assertEqual(gs, GraphSet([g12]))

--- a/graphillion/test/graphset.py
+++ b/graphillion/test/graphset.py
@@ -324,7 +324,8 @@ class TestGraphSet(unittest.TestCase):
         self.assertTrue([(1, 2), (1, 3), (2, 3)] not in gs)
         self.assertTrue([(1, 2), (1, 3), (2, 3), (3, 4)] not in gs)
 
-        graphset = GraphSet([[(1, 2), (1, 3), (2, 3)], [(1, 2), (2, 3), (3, 4)]])
+        graphset = GraphSet(
+            [[(1, 2), (1, 3), (2, 3)], [(1, 2), (2, 3), (3, 4)]])
         gs = GraphSet.bipartite_graphs(graphset=graphset)
         self.assertTrue([(1, 2), (2, 3), (3, 4)] in gs)
         self.assertTrue([(1, 2), (1, 3), (3, 4)] not in gs)

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,8 @@ sources_list = [os.path.join('src', 'pygraphillion.cc'),
                 os.path.join('src', 'graphillion', 'zdd.cc'),
                 os.path.join('src', 'SAPPOROBDD', 'bddc.c'),
                 os.path.join('src', 'SAPPOROBDD', 'BDD.cc'),
-                os.path.join('src', 'SAPPOROBDD', 'ZBDD.cc')]
+                os.path.join('src', 'SAPPOROBDD', 'ZBDD.cc'),
+                os.path.join('src', 'graphillion', 'odd_edges_subgraphs', 'OddEdgeSubgraphs.cc')]
 
 if sys.platform == 'win32':
     sources_list.append(os.path.join('src', 'mingw32', 'RpWinResource.c'))

--- a/src/graphillion/odd_edges_subgraphs/OddEdgeSubgraphs.cc
+++ b/src/graphillion/odd_edges_subgraphs/OddEdgeSubgraphs.cc
@@ -1,0 +1,47 @@
+#include "graphillion/setset.h"
+
+#include "subsetting/DdSpec.hpp"
+#include "subsetting/DdStructure.hpp"
+#include "subsetting/eval/ToZBDD.hpp"
+#include "subsetting/util/Graph.hpp"
+
+#include <assert.h>
+
+class OddEdgeSubgraphSpec : public tdzdd::DdSpec<OddEdgeSubgraphSpec, bool, 2> {
+  const int n;
+
+ public:
+  OddEdgeSubgraphSpec(tdzdd::Graph const& _g) : n(_g.edgeSize()) {}
+
+  int getRoot(bool& is_odd) const {
+    is_odd = false;
+    return n;
+  }
+
+  int getChild(bool& is_odd, int level, int take) const {
+    assert(1 <= level && level <= n);
+
+    if (take) {
+      is_odd = !is_odd;
+    }
+    if (--level == 0) return (is_odd ? -1 : 0);
+    return level;
+  }
+};
+
+namespace graphillion {
+setset SearchOddEdgeSubgraphs(const std::vector<edge_t>& edges) {
+  tdzdd::Graph g;
+  for (const auto& e : edges) {
+    g.addEdge(e.first, e.second);
+  }
+  g.update();
+
+  OddEdgeSubgraphSpec spec(g);
+  auto dd = tdzdd::DdStructure<2>(spec);
+  dd.zddReduce();
+  zdd_t f = dd.evaluate(ToZBDD(setset::max_elem() - setset::num_elems()));
+
+  return setset(f);
+}
+}  // namespace graphillion

--- a/src/graphillion/odd_edges_subgraphs/OddEdgeSubgraphs.cc
+++ b/src/graphillion/odd_edges_subgraphs/OddEdgeSubgraphs.cc
@@ -37,11 +37,18 @@ setset SearchOddEdgeSubgraphs(const std::vector<edge_t>& edges) {
   }
   g.update();
 
-  OddEdgeSubgraphSpec spec(g);
-  auto dd = tdzdd::DdStructure<2>(spec);
-  dd.zddReduce();
-  zdd_t f = dd.evaluate(ToZBDD(setset::max_elem() - setset::num_elems()));
+#ifdef _OPENMP
+  bool use_mp = (omp_get_num_procs() >= 2);
+#else
+  bool use_mp = false;
+#endif
 
+  OddEdgeSubgraphSpec spec(g);
+  auto dd = tdzdd::DdStructure<2>(spec, use_mp);
+  dd.zddReduce();
+
+  dd.useMultiProcessors(false);
+  zdd_t f = dd.evaluate(ToZBDD(setset::max_elem() - setset::num_elems()));
   return setset(f);
 }
 }  // namespace graphillion

--- a/src/graphillion/odd_edges_subgraphs/OddEdgeSubgraphs.h
+++ b/src/graphillion/odd_edges_subgraphs/OddEdgeSubgraphs.h
@@ -1,0 +1,10 @@
+#ifndef GRAPHILLION_ODD_EDGE_SUBGRAPH_SPEC_H_
+#define GRAPHILLION_ODD_EDGE_SUBGRAPH_SPEC_H_
+
+#include "OddEdgeSubgraphs.h"
+
+namespace graphillion {
+setset SearchOddEdgeSubgraphs(const std::vector<edge_t> &edges);
+}  // namespace graphillion
+
+#endif

--- a/src/graphillion/odd_edges_subgraphs/OddEdgeSubgraphs.h
+++ b/src/graphillion/odd_edges_subgraphs/OddEdgeSubgraphs.h
@@ -4,6 +4,9 @@
 #include "OddEdgeSubgraphs.h"
 
 namespace graphillion {
+/**
+ * @return A setset that represents the set of subgraphs with odd edges.
+ */
 setset SearchOddEdgeSubgraphs(const std::vector<edge_t> &edges);
 }  // namespace graphillion
 

--- a/src/graphillion/setset.h
+++ b/src/graphillion/setset.h
@@ -205,6 +205,7 @@ class setset {
       bool no_loop,
       const setset* search_space,
       const std::vector<linear_constraint_t>* linear_constraints);
+  friend setset SearchOddEdgeSubgraphs(const std::vector<edge_t> &edges);
 };
 
 }  // namespace graphillion

--- a/src/graphillion/setset.h
+++ b/src/graphillion/setset.h
@@ -205,7 +205,7 @@ class setset {
       bool no_loop,
       const setset* search_space,
       const std::vector<linear_constraint_t>* linear_constraints);
-  friend setset SearchOddEdgeSubgraphs(const std::vector<edge_t> &edges);
+  friend setset SearchOddEdgeSubgraphs(const std::vector<edge_t>& edges);
 };
 
 }  // namespace graphillion

--- a/src/pygraphillion.cc
+++ b/src/pygraphillion.cc
@@ -1365,8 +1365,8 @@ static PyObject* odd_edges_subgraphs(PyObject*, PyObject* args, PyObject* kwds) 
   }
 
   auto ss = graphillion::SearchOddEdgeSubgraphs(graph);
-  PySetsetObject* ret = reinterpret_cast<PySetsetObject*>
-      (PySetset_Type.tp_alloc(&PySetset_Type, 0));
+  PySetsetObject* ret = reinterpret_cast<PySetsetObject*>(
+      PySetset_Type.tp_alloc(&PySetset_Type, 0));
   ret->ss = new setset(ss);
   return reinterpret_cast<PyObject*>(ret);
 }

--- a/src/pygraphillion.cc
+++ b/src/pygraphillion.cc
@@ -41,6 +41,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "graphillion/graphset.h"
 
+#include "graphillion/odd_edges_subgraphs/OddEdgeSubgraphs.h"
+
 using graphillion::setset;
 using graphillion::Range;
 using graphillion::vertex_t;
@@ -1325,6 +1327,50 @@ static PyObject* graphset_show_messages(PySetsetObject* self, PyObject* obj) {
   else Py_RETURN_FALSE;
 }
 
+static PyObject* odd_edges_subgraphs(PyObject*, PyObject* args, PyObject* kwds) {
+  static char s1[] = "graph";
+  static char* kwlist[2] = {s1, NULL};
+  PyObject* graph_obj = NULL;
+  if (!PyArg_ParseTupleAndKeywords(args, kwds, "O", kwlist, &graph_obj)) {
+    return NULL;
+  }
+
+  vector<pair<string, string> > graph;
+  if (graph_obj == NULL || graph_obj == Py_None) {
+    PyErr_SetString(PyExc_TypeError, "no graph");
+    return NULL;
+  }
+  PyObject* i = PyObject_GetIter(graph_obj);
+  if (i == NULL) return NULL;
+  PyObject* eo;
+  while ((eo = PyIter_Next(i))) {
+    PyObject* j = PyObject_GetIter(eo);
+    if (j == NULL) return NULL;
+    vector<string> e;
+    PyObject* vo;
+    while ((vo = PyIter_Next(j))) {
+      if (!PyBytes_Check(vo)) {
+        PyErr_SetString(PyExc_TypeError, "invalid graph");
+        return NULL;
+      }
+      string v = PyBytes_AsString(vo);
+      if (v.find(',') != string::npos) {
+        PyErr_SetString(PyExc_TypeError, "invalid vertex in the graph");
+        return NULL;
+      }
+      e.push_back(v);
+    }
+    assert(e.size() == 2);
+    graph.push_back(make_pair(e[0], e[1]));
+  }
+
+  auto ss = graphillion::SearchOddEdgeSubgraphs(graph);
+  PySetsetObject* ret = reinterpret_cast<PySetsetObject*>
+      (PySetset_Type.tp_alloc(&PySetset_Type, 0));
+  ret->ss = new setset(ss);
+  return reinterpret_cast<PyObject*>(ret);
+}
+
 static PyMethodDef module_methods[] = {
   {"load", reinterpret_cast<PyCFunction>(setset_load), METH_O, ""},
   {"loads", reinterpret_cast<PyCFunction>(setset_loads), METH_O, ""},
@@ -1332,6 +1378,7 @@ static PyMethodDef module_methods[] = {
   {"_num_elems", setset_num_elems, METH_VARARGS, ""},
   {"_graphs", reinterpret_cast<PyCFunction>(graphset_graphs), METH_VARARGS | METH_KEYWORDS, ""},
   {"_show_messages", reinterpret_cast<PyCFunction>(graphset_show_messages), METH_O, ""},
+  {"_odd_edges_subgraphs", reinterpret_cast<PyCFunction>(odd_edges_subgraphs), METH_VARARGS | METH_KEYWORDS, ""},
   {NULL}  /* Sentinel */
 };
 


### PR DESCRIPTION
OddEdgeSubgraphs.h/.cc construct a ZDD that represents the set of subgraphs with odd edges.
bipartite_graphs() constructs a DD with the followings steps.
1. `Z_1`: construct a DD that represents the set of subgraphs with odd edges.
2. `Z_2`: construct a DD that represents the set of odd cycles from `Z_1`.
3. `Z_3`: construct a DD using non_superset() with `Z_2`.
4. return `Z_3`.