### PR TITLE
Optimize trees(is_spanning=True) by switching to vertex_groups encoding

### DIFF
--- a/graphillion/graphset.py
+++ b/graphillion/graphset.py
@@ -2103,13 +2103,19 @@ class GraphSet(object):
         See Also:
           graphs()
         """
-        vg = [[]] if root is None else [[root]]
-        dc = None
         if is_spanning:
-            dc = {}
-            for v in Universe.vertices:
-                dc[v] = range(1, len(Universe.vertices))
-        return GraphSet.graphs(vertex_groups=vg, degree_constraints=dc,
+            # `root` is irrelevant in spanning mode (every spanning tree
+            # contains every vertex). Use a single color group covering all
+            # vertices: the all-colored DP collapses touched/untouched
+            # distinctions and reaches the theoretical-minimum state count
+            # P(k) per frontier, dramatically smaller than the legacy
+            # vg=[[root]] + DegreeConstraint(deg>=1) path (which had
+            # (Δ+1)^k state inflation from the per-vertex degree counter).
+            return GraphSet.graphs(vertex_groups=[list(Universe.vertices)],
+                                   no_loop=True,
+                                   graphset=graphset)
+        vg = [[]] if root is None else [[root]]
+        return GraphSet.graphs(vertex_groups=vg, degree_constraints=None,
                                no_loop=True, graphset=graphset)
 
     @staticmethod


### PR DESCRIPTION
The previous implementation expressed "spanning" as a per-vertex DegreeConstraint(deg>=1) intersected with the colored frontier-based search. The DegreeConstraint maintains an exact running degree counter (int16) per frontier vertex (subsetting/spec/DegreeConstraint.hpp), so its state space grows as O((deg+1)^k) where k is the frontier width and deg is the maximum vertex degree.

Equivalently, a spanning tree can be expressed as

    graphs(vertex_groups=[V_all], no_loop=True)

i.e. a single color group covering every vertex plus the no-loop constraint. The all-colored frontier-based search reaches the theoretical minimum state count P(k) (Bell number of frontier partitions) without the degree counter, and produces the same set.

Because every spanning tree contains every vertex, the optional `root` argument is redundant in spanning mode and is dropped from the dispatch (any choice of root yields the same set).

Benchmarks (best of 3, m up to 30 edges):

  graph                  m | legacy ms -> new ms |  speedup
  -------------------------|---------------------|---------
  grid 4x4              24 |    0.41 ->    0.11  |   3.7x
  grid 4x5              31 |    1.78 ->    0.14  |  12.7x
  random n=10,m=25      25 |    2.02 ->    0.12  |  16.8x
  random n=12,m=30      30 |    7.72 ->    0.30  |  25.7x
  scale-free n=18,m=30  30 |    2.87 ->    0.16  |  17.9x

Peak intermediate ZDD nodes drop accordingly (e.g. 56928 -> 2517 on random n=12,m=30), reaching the theoretical minimum (== final ZDD node count) on most cases.

All 35 existing tests in graphillion/test/graphset.py pass.