### PR TITLE
Fix incorrect `Py_XDECREF/Py_DECREF` call on stolen reference after `PyList_SetItem` failure

### DIFF
--- a/src/pygraphillion.cc
+++ b/src/pygraphillion.cc
@@ -2535,7 +2535,6 @@ static PyObject* setset_get_vertices_from_top(PySetsetObject* self, PyObject* ar
       return NULL;
     }
     if (PyList_SetItem(ret, i, v) != 0) {
-      Py_DECREF(v);
       Py_DECREF(ret);
       return NULL;
     }


### PR DESCRIPTION
Close #78 